### PR TITLE
Fix membership check to skip when player lookup fails

### DIFF
--- a/cocbot/tasks.py
+++ b/cocbot/tasks.py
@@ -28,7 +28,10 @@ async def membership_check() -> None:
         if member is None:
             continue
         player = await get_player(item["player_tag"])
-        if player is None or not player.clan or player.clan.tag.upper() != CLAN_TAG.upper():
+        if player is None:
+            log.warning("Skipping member %s due to failed player lookup", member)
+            continue
+        if not player.clan or player.clan.tag.upper() != CLAN_TAG.upper():
             try:
                 await member.kick(reason="Left clan")
             except discord.Forbidden:


### PR DESCRIPTION
## Summary
- avoid kicking when the Clash of Clans API lookup fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bfe1c1e54832c9d2b2cccd0da65e5