### PR TITLE
fix(ci): resolve ECR authentication failure + modularity refactor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
     outputs:
       rebuild_bot: ${{ steps.strategy.outputs.rebuild_bot }}
       rebuild_giveaway: ${{ steps.strategy.outputs.rebuild_giveaway }}
-      ecr_registry: ${{ steps.login.outputs.registry }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -48,10 +47,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
-        id: login
 
       - name: Determine build strategy
         id: strategy
@@ -113,6 +108,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+        id: login
+
       - name: Set up Python (for dependency caching)
         uses: actions/setup-python@v5
         with:
@@ -133,7 +132,7 @@ jobs:
           file: ./${{ matrix.dockerfile }}
           platforms: linux/arm64
           push: true
-          tags: ${{ needs.setup.outputs.ecr_registry }}/${{ matrix.ecr_repository }}:${{ github.sha }}
+          tags: ${{ steps.login.outputs.registry }}/${{ matrix.ecr_repository }}:${{ github.sha }}
           cache-from: |
             type=gha,scope=${{ matrix.cache_scope }}-deps
             type=gha,scope=${{ matrix.cache_scope }}-runtime
@@ -146,7 +145,7 @@ jobs:
         if: matrix.rebuild_condition == 'true'
         run: |
           echo "🔨 Built ${{ matrix.service }} with caching"
-          echo "IMAGE=${{ needs.setup.outputs.ecr_registry }}/${{ matrix.ecr_repository }}:${{ github.sha }}" >> $GITHUB_ENV
+          echo "IMAGE=${{ steps.login.outputs.registry }}/${{ matrix.ecr_repository }}:${{ github.sha }}" >> $GITHUB_ENV
           echo "IMAGE_BUILT=true" >> $GITHUB_ENV
 
       - name: Reuse existing ${{ matrix.service }} image
@@ -159,7 +158,7 @@ jobs:
             --region $AWS_REGION \
             --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' \
             --output text)
-          echo "IMAGE=${{ needs.setup.outputs.ecr_registry }}/${{ matrix.ecr_repository }}:$LATEST_TAG" >> $GITHUB_ENV
+          echo "IMAGE=${{ steps.login.outputs.registry }}/${{ matrix.ecr_repository }}:$LATEST_TAG" >> $GITHUB_ENV
           echo "IMAGE_BUILT=false" >> $GITHUB_ENV
 
       - name: Deploy ${{ matrix.service }} (conditional)


### PR DESCRIPTION
## Summary
- Resolves ECR authentication failures in deploy workflow by moving ECR login to individual build-deploy jobs
- Includes modularity refactor from previous commit

## ECR Authentication Fix
The deployment failures were caused by ECR authentication tokens from the setup job not being available to the separate build-deploy matrix job runners. Fixed by:

- Move `aws-actions/amazon-ecr-login@v1` to each build-deploy job
- Remove `ecr_registry` output from setup job  
- Update Docker build references to use local ECR registry

## Test plan
- [x] Deploy workflow should complete without 401 Unauthorized errors
- [x] Both bot and giveaway images should build and push to ECR successfully
- [x] ECS services should deploy with new images

🤖 Generated with [Claude Code](https://claude.ai/code)