### PR TITLE
Fix verifier removal workflow on auth failures

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -396,9 +396,7 @@ async def membership_check() -> None:
                     "Skipping membership check for %s due to CoC API access denial",
                     item["player_tag"],
                 )
-                await approvals.clear_pending_removals_for_target(
-                    table, discord_id_str
-                )
+                await approvals.clear_pending_removals_for_target(table, discord_id_str)
                 continue
 
             if fetch_result.status == "error":

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -639,9 +639,7 @@ class TestMembershipCheck:
         mock_member = MagicMock()
         mock_guild.get_member.return_value = mock_member
 
-        fetch_result = SimpleNamespace(
-            status="not_found", player=None, exception=None
-        )
+        fetch_result = SimpleNamespace(status="not_found", player=None, exception=None)
 
         with (
             patch.object(bot, "table", mock_table),
@@ -693,8 +691,12 @@ class TestMembershipCheck:
         mock_guild.get_member.return_value = mock_member
 
         fetch_results = {
-            "#PLAYER1": SimpleNamespace(status="not_found", player=None, exception=None),
-            "#PLAYER2": SimpleNamespace(status="not_found", player=None, exception=None),
+            "#PLAYER1": SimpleNamespace(
+                status="not_found", player=None, exception=None
+            ),
+            "#PLAYER2": SimpleNamespace(
+                status="not_found", player=None, exception=None
+            ),
         }
 
         async def mock_fetch_player_with_status(*args, **kwargs):
@@ -1629,7 +1631,9 @@ class TestMembershipCheckAuthFailures:
         mock_member.id = 123456789
         mock_guild.get_member.return_value = mock_member
 
-        fetch_result = SimpleNamespace(status="access_denied", player=None, exception=None)
+        fetch_result = SimpleNamespace(
+            status="access_denied", player=None, exception=None
+        )
 
         with (
             patch.object(bot, "table", mock_table),

--- a/verifier_bot/approvals.py
+++ b/verifier_bot/approvals.py
@@ -418,7 +418,9 @@ async def clear_pending_removals_for_target(table, target_discord_id: str) -> in
 
         if removed:
             log.info(
-                "Removed %d pending removal request(s) for %s", removed, target_discord_id
+                "Removed %d pending removal request(s) for %s",
+                removed,
+                target_discord_id,
             )
         return removed
 


### PR DESCRIPTION
## Summary
- differentiate Clash API access-denied errors from members leaving the clan
- stop queuing removal approvals when auth fails and clear pending bogus requests
- add coverage for auth failure handling and pending removal cleanup

## Testing
- .venv/bin/pytest