### PR TITLE
Add registration window experience

### DIFF
--- a/tests/test_tournament_storage.py
+++ b/tests/test_tournament_storage.py
@@ -62,6 +62,8 @@ def sample_config() -> TournamentConfig:
         team_size=5,
         allowed_town_halls=[16, 17],
         max_teams=10,
+        registration_opens_at="2024-01-01T00:00:00.000Z",
+        registration_closes_at="2024-01-05T00:00:00.000Z",
         updated_by=99,
         updated_at="2024-01-01T00:00:00.000Z",
     )
@@ -73,8 +75,16 @@ def sample_registration() -> TeamRegistration:
         user_id=7,
         user_name="User#1234",
         players=[
-            PlayerEntry(name="One", tag="#AAA111", town_hall=16),
-            PlayerEntry(name="Two", tag="#BBB222", town_hall=17),
+            PlayerEntry(
+                name="One",
+                tag="#AAA111",
+                town_hall=16,
+                clan_name="Alpha",
+                clan_tag="#CLAN1",
+            ),
+            PlayerEntry(
+                name="Two", tag="#BBB222", town_hall=17, clan_name=None, clan_tag=None
+            ),
         ],
         registered_at="2024-01-01T00:00:00.000Z",
     )
@@ -93,6 +103,9 @@ def test_config_round_trip():
 
     restored = storage.get_config(config.guild_id)
     assert restored == config
+    opens_at, closes_at = restored.registration_window()
+    assert opens_at.year == 2024
+    assert closes_at.day == 5
 
 
 def test_config_missing_returns_none():

--- a/tests/test_tournamentbot_helpers.py
+++ b/tests/test_tournamentbot_helpers.py
@@ -12,12 +12,15 @@ def test_format_config_message_includes_details():
         team_size=10,
         allowed_town_halls=[16, 17],
         max_teams=20,
+        registration_opens_at="2024-05-01T18:00:00.000Z",
+        registration_closes_at="2024-05-10T18:00:00.000Z",
         updated_by=0,
         updated_at="2024-01-01T00:00:00.000Z",
     )
     message = tournamentbot.format_config_message(config)
     assert "Team size: 10" in message
     assert "Allowed Town Halls: 16, 17" in message
+    assert "Registration: May 01, 2024 18:00 UTC — May 10, 2024 18:00 UTC" in message
 
 
 def test_ensure_guild_validates_presence():
@@ -32,14 +35,20 @@ def test_ensure_guild_validates_presence():
 @pytest.mark.asyncio
 async def test_fetch_players_returns_entries(monkeypatch):
     async def fake_get_player(_client, _email, _password, tag):
-        return SimpleNamespace(name=f"Player{tag[-1]}", town_hall_level=17)
+        return SimpleNamespace(
+            name=f"Player{tag[-1]}",
+            town_hall_level=17,
+            clan=SimpleNamespace(name="Clan", tag="#CLAN"),
+        )
 
     monkeypatch.setattr(tournamentbot.coc_api, "get_player_with_retry", fake_get_player)
+    tournamentbot.coc_client = SimpleNamespace()
 
     players = await tournamentbot.fetch_players(["#AAA111", "#BBB222"])
 
     assert [player.tag for player in players] == ["#AAA111", "#BBB222"]
     assert all(player.town_hall == 17 for player in players)
+    assert players[0].clan_name == "Clan"
 
 
 @pytest.mark.asyncio
@@ -50,6 +59,7 @@ async def test_fetch_players_raises_when_missing_data(monkeypatch):
         return None
 
     monkeypatch.setattr(tournamentbot.coc_api, "get_player_with_retry", fake_get_player)
+    tournamentbot.coc_client = SimpleNamespace()
 
     with pytest.raises(tournamentbot.InvalidValueError):
         await tournamentbot.fetch_players(["#AAA111", "#BBB222"])

--- a/tournament_bot/__init__.py
+++ b/tournament_bot/__init__.py
@@ -7,8 +7,10 @@ from .validation import (
     InvalidValueError,
     normalize_player_tag,
     parse_player_tags,
+    parse_registration_datetime,
     parse_town_hall_levels,
     validate_max_teams,
+    validate_registration_window,
     validate_team_size,
 )
 
@@ -22,7 +24,9 @@ __all__ = [
     "InvalidValueError",
     "normalize_player_tag",
     "parse_player_tags",
+    "parse_registration_datetime",
     "parse_town_hall_levels",
     "validate_max_teams",
+    "validate_registration_window",
     "validate_team_size",
 ]

--- a/tournamentbot.py
+++ b/tournamentbot.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from datetime import UTC, datetime
 from typing import Final
 
 import boto3
 import coc
 import discord
 from discord import app_commands
+from discord.abc import Messageable
 from discord.app_commands import errors as app_errors
 
 from tournament_bot import (
@@ -22,9 +24,11 @@ from tournament_bot import (
     TournamentConfig,
     TournamentStorage,
     parse_player_tags,
+    parse_registration_datetime,
     parse_town_hall_levels,
     utc_now_iso,
     validate_max_teams,
+    validate_registration_window,
     validate_team_size,
 )
 from verifier_bot import coc_api
@@ -62,21 +66,117 @@ dynamodb = boto3.resource("dynamodb", region_name=AWS_REGION)
 table = dynamodb.Table(TOURNAMENT_TABLE_NAME) if TOURNAMENT_TABLE_NAME else None
 storage = TournamentStorage(table)
 
-coc_client = coc.Client()
+coc_client: coc.Client | None = None
 
 
-def format_config_message(config: TournamentConfig) -> str:
+def isoformat_utc(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def format_display(dt: datetime) -> str:
+    return dt.astimezone(UTC).strftime("%b %d, %Y %H:%M UTC")
+
+
+def format_config_message(
+    config: TournamentConfig,
+    *,
+    opens_at: datetime | None = None,
+    closes_at: datetime | None = None,
+) -> str:
+    if opens_at is None or closes_at is None:
+        try:
+            opens_at, closes_at = config.registration_window()
+        except (ValueError, AttributeError):
+            opens_at = closes_at = None
+
     allowed = ", ".join(str(level) for level in config.allowed_town_halls)
+    window = (
+        f"{format_display(opens_at)} — {format_display(closes_at)}"
+        if opens_at and closes_at
+        else "Not configured"
+    )
     return (
-        "Tournament configuration updated:\n"
+        "Tournament configuration updated.\n"
+        f"- Registration: {window}\n"
         f"- Team size: {config.team_size}\n"
         f"- Allowed Town Halls: {allowed}\n"
         f"- Maximum teams: {config.max_teams}"
     )
 
 
+def build_setup_embed(
+    config: TournamentConfig,
+    *,
+    opens_at: datetime,
+    closes_at: datetime,
+    requested_by: discord.abc.User,
+) -> discord.Embed:
+    embed = discord.Embed(
+        title="Clash Time!",
+        description="Registration window is locked. Rally your squad!",
+        color=discord.Color.orange(),
+        timestamp=closes_at,
+    )
+    embed.add_field(
+        name="Registration Window",
+        value=f"{format_display(opens_at)} — {format_display(closes_at)}",
+        inline=False,
+    )
+    embed.add_field(
+        name="Team Size",
+        value=f"{config.team_size} players",
+        inline=True,
+    )
+    embed.add_field(
+        name="Allowed Town Halls",
+        value=", ".join(str(level) for level in config.allowed_town_halls),
+        inline=True,
+    )
+    embed.add_field(
+        name="Max Teams",
+        value=str(config.max_teams),
+        inline=True,
+    )
+    embed.set_footer(text=f"Configured by {requested_by}")
+    return embed
+
+
+def build_registration_embed(
+    registration: TeamRegistration,
+    *,
+    config: TournamentConfig,
+    closes_at: datetime,
+    is_update: bool,
+) -> discord.Embed:
+    embed = discord.Embed(
+        title="Team registration updated!" if is_update else "Team registered!",
+        description=f"Captain: {registration.user_name}",
+        color=discord.Color.green(),
+        timestamp=datetime.now(UTC),
+    )
+    players_value = "\n".join(registration.lines_for_channel)
+    embed.add_field(name="Lineup", value=players_value, inline=False)
+    embed.set_footer(text=f"Teams lock {format_display(closes_at)}")
+    embed.add_field(
+        name="Team Size",
+        value=f"{len(registration.players)}/{config.team_size}",
+        inline=True,
+    )
+    embed.add_field(
+        name="Town Halls",
+        value=", ".join(
+            sorted({f"TH{player.town_hall}" for player in registration.players})
+        )
+        or "-",
+        inline=True,
+    )
+    return embed
+
+
 async def fetch_players(tags: list[str]) -> list[PlayerEntry]:
     async def fetch(tag: str) -> PlayerEntry:
+        if coc_client is None:
+            raise RuntimeError("Clash of Clans client is not initialized")
         player = await coc_api.get_player_with_retry(
             coc_client, COC_EMAIL, COC_PASSWORD, tag
         )
@@ -89,7 +189,16 @@ async def fetch_players(tags: list[str]) -> list[PlayerEntry]:
             raise InvalidValueError(
                 f"Unable to determine town hall for {player.name} ({tag})"
             )
-        return PlayerEntry(name=player.name, tag=tag, town_hall=int(town_hall))
+        clan = getattr(player, "clan", None)
+        clan_name = getattr(clan, "name", None) if clan else None
+        clan_tag = getattr(clan, "tag", None) if clan else None
+        return PlayerEntry(
+            name=player.name,
+            tag=tag,
+            town_hall=int(town_hall),
+            clan_name=clan_name,
+            clan_tag=clan_tag,
+        )
 
     player_entries = await asyncio.gather(*[fetch(tag) for tag in tags])
     return list(player_entries)
@@ -108,6 +217,8 @@ def ensure_guild(interaction: discord.Interaction) -> discord.Guild:
     team_size="Number of players per team (increments of 5)",
     allowed_town_halls="Comma or space separated Town Hall levels (e.g. 16 17)",
     max_teams="Maximum teams allowed (increments of 2)",
+    registration_opens="When registration opens (UTC, e.g. 2024-05-01T18:00)",
+    registration_closes="When registration closes (UTC, e.g. 2024-05-10T22:00)",
 )
 @tree.command(name="setup", description="Configure tournament registration rules")
 async def setup_command(  # pragma: no cover - Discord slash command wiring
@@ -115,12 +226,19 @@ async def setup_command(  # pragma: no cover - Discord slash command wiring
     team_size: int,
     allowed_town_halls: str,
     max_teams: int,
+    registration_opens: str,
+    registration_closes: str,
 ) -> None:
     try:
         guild = ensure_guild(interaction)
         team_size_validated = validate_team_size(team_size)
         allowed_levels = parse_town_hall_levels(allowed_town_halls)
         max_teams_validated = validate_max_teams(max_teams)
+        opens_at_input = parse_registration_datetime(registration_opens)
+        closes_at_input = parse_registration_datetime(registration_closes)
+        opens_at, closes_at = validate_registration_window(
+            opens_at_input, closes_at_input
+        )
     except (InvalidValueError, InvalidTownHallError) as exc:
         await interaction.response.send_message(str(exc), ephemeral=True)
         return
@@ -134,19 +252,42 @@ async def setup_command(  # pragma: no cover - Discord slash command wiring
         await interaction.response.send_message(str(exc), ephemeral=True)
         return
 
+    if closes_at <= datetime.now(UTC):
+        await interaction.response.send_message(
+            "Registration end must be in the future.",
+            ephemeral=True,
+        )
+        return
+
     config = TournamentConfig(
         guild_id=guild.id,
         team_size=team_size_validated,
         allowed_town_halls=allowed_levels,
         max_teams=max_teams_validated,
+        registration_opens_at=isoformat_utc(opens_at),
+        registration_closes_at=isoformat_utc(closes_at),
         updated_by=interaction.user.id,
         updated_at=utc_now_iso(),
     )
     storage.save_config(config)
 
-    await interaction.response.send_message(
-        format_config_message(config), ephemeral=True
-    )
+    ack_message = format_config_message(config, opens_at=opens_at, closes_at=closes_at)
+    await interaction.response.send_message(ack_message, ephemeral=True)
+
+    channel = interaction.channel
+    if isinstance(channel, Messageable):
+        embed = build_setup_embed(
+            config,
+            opens_at=opens_at,
+            closes_at=closes_at,
+            requested_by=interaction.user,
+        )
+        try:
+            await channel.send(embed=embed)
+        except discord.HTTPException as exc:  # pragma: no cover - network failure
+            log.warning("Failed to send setup announcement: %s", exc)
+    else:
+        log.debug("Skipping channel announcement; channel not messageable")
 
 
 @setup_command.error
@@ -204,6 +345,30 @@ async def register_team_command(  # pragma: no cover - Discord slash command wir
         return
 
     try:
+        opens_at, closes_at = config.registration_window()
+    except ValueError:
+        log.error("Configuration for guild %s is missing registration window", guild.id)
+        await interaction.response.send_message(
+            "Tournament registration window is missing. Please ping an admin to re-run /setup.",
+            ephemeral=True,
+        )
+        return
+
+    now = datetime.now(UTC)
+    if now < opens_at:
+        await interaction.response.send_message(
+            f"Registration hasn't opened yet. Come back {format_display(opens_at)}.",
+            ephemeral=True,
+        )
+        return
+    if now >= closes_at:
+        await interaction.response.send_message(
+            f"Registration closed {format_display(closes_at)}. Teams are locked—please contact an admin for help.",
+            ephemeral=True,
+        )
+        return
+
+    try:
         tags = parse_player_tags(player_tags)
     except InvalidValueError as exc:
         await interaction.response.send_message(str(exc), ephemeral=True)
@@ -247,8 +412,7 @@ async def register_team_command(  # pragma: no cover - Discord slash command wir
     ]
     if disallowed:
         lines = ", ".join(
-            f"{player.name} ({player.tag}) TH{player.town_hall}"
-            for player in disallowed
+            f"{player.name} (TH{player.town_hall})" for player in disallowed
         )
         await interaction.followup.send(
             f"These players have unsupported Town Hall levels: {lines}",
@@ -265,13 +429,20 @@ async def register_team_command(  # pragma: no cover - Discord slash command wir
     )
     storage.save_registration(registration)
 
-    prefix = (
-        "Team registration updated!"
-        if existing_registration
-        else "Team registered successfully!"
+    embed = build_registration_embed(
+        registration,
+        config=config,
+        closes_at=closes_at,
+        is_update=existing_registration is not None,
     )
-    message = "\n".join([prefix, *registration.lines_for_channel])
-    await interaction.followup.send(message)
+    try:
+        await interaction.followup.send(embed=embed)
+    except discord.HTTPException as exc:  # pragma: no cover - network failure
+        log.warning("Failed to send registration embed: %s", exc)
+        await interaction.followup.send(
+            "Team registered, but I couldn't post the announcement.",
+            ephemeral=True,
+        )
 
 
 # ---------- Lifecycle ----------
@@ -279,6 +450,9 @@ async def register_team_command(  # pragma: no cover - Discord slash command wir
 async def on_ready() -> None:  # pragma: no cover - Discord lifecycle hook
     await tree.sync()
     log.info("Signing in to CoC API for tournament bot...")
+    global coc_client
+    if coc_client is None:
+        coc_client = coc.Client()
     await coc_client.login(COC_EMAIL, COC_PASSWORD)
     log.info("Tournament bot ready as %s (%s)", bot.user, bot.user.id)
 
@@ -294,7 +468,8 @@ async def main() -> None:  # pragma: no cover - CLI entry point
         async with bot:
             await bot.start(DISCORD_TOKEN)  # type: ignore[arg-type]
     finally:
-        await coc_client.close()
+        if coc_client is not None:
+            await coc_client.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- gate team registration behind configured start/end timestamps and display polished embeds for setup + registration
- enrich stored player metadata to include clan details and update channel formatting to highlight TH+clan
- harden validation utilities and tests to cover new flows and iso datetime parsing

## Testing
- nox -s lint
- nox -s tests
